### PR TITLE
add kitchen test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,11 @@ URL: http://graphql.org
     https://github.com/ropensci/graphql
 BugReports: https://github.com/ropensci/graphql/issues
 LinkingTo: Rcpp
-Imports: 
-    Rcpp (>= 0.12.0), 
+Imports:
+    Rcpp (>= 0.12.0),
     jsonlite
-LazyData: true
-SystemRequirements: C++11
-RoxygenNote: 5.0.1.9000
+LazyData: NA
+SystemRequirements: NA
+RoxygenNote: 5.0.1
+Suggests:
+    testthat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(graphql)
+
+test_check("graphql")

--- a/tests/testthat/test-kitchen_sink.R
+++ b/tests/testthat/test-kitchen_sink.R
@@ -1,0 +1,72 @@
+context("kitchen_sink")
+
+test_that("kitchen sink parses", {
+
+  kitchen_txt <-
+    "
+    # Copyright (c) 2015, Facebook, Inc.
+    # All rights reserved.
+    #
+    # This source code is licensed under the BSD-style license found in the
+    # LICENSE file in the root directory of this source tree. An additional grant
+    # of patent rights can be found in the PATENTS file in the same directory.
+
+    query queryName($foo: ComplexType, $site: Site = MOBILE) {
+      whoever123is: node(id: [123, 456]) {
+        id ,
+        ... on User @defer {
+          field2 {
+            id ,
+            alias: field1(first:10, after:$foo,) @include(if: $foo) {
+              id,
+              ...frag
+            }
+          }
+        }
+        ... @skip(unless: $foo) {
+          id
+        }
+        ... {
+          id
+        }
+      }
+    }
+
+    mutation likeStory {
+      like(story: 123) @defer {
+        story {
+          id
+        }
+      }
+    }
+
+    subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+      storyLikeSubscribe(input: $input) {
+        story {
+          likers {
+            count
+          }
+          likeSentence {
+            text
+          }
+        }
+      }
+    }
+
+    fragment frag on Friend {
+      foo(size: $size, bar: $b, obj: {key: \"value\"})
+    }
+
+    {
+      unnamed(truthy: true, falsey: false, nullish: null),
+      query
+    }
+    "
+
+    json_txt <- graphql2json(kitchen_txt)
+
+    result <- jsonlite::fromJSON(json_txt)
+
+    expect_true(is.list(result))
+
+})


### PR DESCRIPTION
hello,

I have added a test that reads the kitchen sink (for queries) provided in Facebook's graphql-js.  Since they are already in the copyright, I figured it would be ok.

libgraphqlparser is not doing well with it.  It is saying there's a missing key, but I'm interpreting it as an extra comma.
```
Failed -------------------------------------------------------------------------
1. Error: kitchen sink parses (@test-kitchen_sink.R#68) ------------------------
parse error: invalid object key (must be a string)
          ,"loc":{"start":53,"end":57},}}],"directives":null,"selectio
                     (right here) ------^
1: jsonlite::fromJSON(json_txt) at /Users/barret/odrive/AmazonCloudDrive/git/R/graphql/graphql/tests/testthat/test-kitchen_sink.R:68
2: fromJSON_string(txt = txt, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame, 
       simplifyMatrix = simplifyMatrix, flatten = flatten, ...)
3: parseJSON(txt, bigint_as_char)
4: parse_string(txt, bigint_as_char)
```

I think this is libgraphqlparser's issue, but I don't know for sure. https://github.com/graphql/libgraphqlparser/blob/master/JsonVisitor.cpp#L33. The nullish values do not have any information except for the location.  So I don't know if the trailing comma is messing things up.

Thank you,
Barret